### PR TITLE
Darken weekend cells for visibility/printability

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -79,7 +79,7 @@ td:empty {
 	color: #888;
 }
 .weekend {
-	background: #eee;
+	background: #d8d8d8;
 	font-weight: 400;
 }
 p {


### PR DESCRIPTION
The previous color, `#eee` was too light to show up on my printer (you had to look _really_ closely to even tell that there was any shading; it did not create the desired visual effect). This one is just a touch darker, at `#d8d8d8`, which I've found is all you need to make sure a light gray background shows up on standard home printers (and works on mine; a kinda low quality all-in-one deskjet).

This was just for me; feel free to disregard, but I thought since I had done it anyway I may as well share.