### PR TITLE
Allow 2-page mode with URL param half=1 or half=2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This is a simple calendar with the full year on a single page. Designed to be printed, it will automatically adjust to any paper size or direction (though it looks best in landscape orientation).
 
-By default, the current year is used. You can override the year by supplying a `year` parameter, e.g. `/calendar.php?year=2027`.
-
-You can also switch to a weekday-aligned rendering by setting the `layout` parameter value to `aligned-weekdays`.
+* By default, the current year is used. You can override the year by supplying a `year` parameter, e.g. `/calendar.php?year=2027`.
+* You can switch to a weekday-aligned rendering by setting the `layout` parameter value to `aligned-weekdays`.
+* You can print the year on two pages by setting the parameter `half=1` or `half=2`.
 
 Unabashedly written in PHP. Print it here: https://neatnik.net/calendar

--- a/calendar.php
+++ b/calendar.php
@@ -125,12 +125,15 @@ $now = isset($_REQUEST['year']) ? strtotime($_REQUEST['year'].'-01-01') : time()
 $dates = array();
 $month = 1;
 $day = 1;
+// print months 1-12 unless half-year view requested
+$month_last = (isset($_REQUEST['half']) && $_REQUEST['half'] == 1) ? 6 : 12;
+$month_first = (isset($_REQUEST['half']) && $_REQUEST['half'] == 2) ? 7 : 1;
 echo '<p>'.date('Y', $now).'</p>';
 echo '<table>';
 echo '<thead>';
 echo '<tr>';
 // Add the month headings
-for($i = 1; $i <= 12; $i++) {
+for($i = $month_first; $i <= $month_last; $i++) {
 	echo '<th>'.DateTime::createFromFormat('!m', $i)->format('M').'</th>';
 }
 echo '</tr>';
@@ -164,7 +167,6 @@ while($month <= 12) {
 			// Ensure that we have a valid date
 			if($day > cal_days_in_month(CAL_GREGORIAN, $month, date('Y', $now))) {
 				$dates[$month][$x] = 0;
-				
 			}
 			else {
 				$dates[$month][$x] = $day;
@@ -177,7 +179,7 @@ while($month <= 12) {
 
 // Now produce the table
 
-$month = 1;
+$month = $month_first;
 $day = 1;
 
 if(isset($_REQUEST['layout']) && $_REQUEST['layout'] == 'aligned-weekdays') {
@@ -185,12 +187,11 @@ if(isset($_REQUEST['layout']) && $_REQUEST['layout'] == 'aligned-weekdays') {
 	while($day <= 42) {
 		echo '<tr>';
 		// Start the inner loop around 12 months
-		while($month <= 12) {
+		while($month <= $month_last) {
 			if($dates[$month][$day] == 0) {
 				echo '<td></td>';
 			}
 			else {
-				
 				$date = date('Y', $now).'-'.str_pad($month, 2, '0', STR_PAD_LEFT).'-'.str_pad($dates[$month][$day], 2, '0', STR_PAD_LEFT);
 				if(date('N', strtotime($date)) == '7') {
 					echo '<td class="weekend">';
@@ -204,10 +205,9 @@ if(isset($_REQUEST['layout']) && $_REQUEST['layout'] == 'aligned-weekdays') {
 			$month++;
 		}
 		echo '</tr>';
-		$month = 1;
+		$month = $month_first;
 		$day++;
 	}
-	
 }
 
 else {
@@ -215,7 +215,7 @@ else {
 	while($day <= 31) {
 		echo '<tr>';
 		// Start the inner loop around 12 months
-		while($month <= 12) {
+		while($month <= $month_last) {
 			// If we’ve reached a point in the date matrix where the resulting date would be invalid (e.g. February 30th), leave the cell blank
 			if($day > cal_days_in_month(CAL_GREGORIAN, $month, date('Y', $now))) {
 				echo '<td></td>';
@@ -235,7 +235,7 @@ else {
 			$month++;
 		}
 		echo '</tr>';
-		$month = 1;
+		$month = $month_first;
 		$day++;
 	}
 }


### PR DESCRIPTION
I love this calendar/the idea behind it! And at first I printed the 1-page version and I thought, this is great but, I need just a _tiny bit_ more space, so I made this 2-page layout and printed it in portrait mode and it looks _fantastic_. I will fold it up and carry it everywhere.
![IMG_20240117_132634654](https://github.com/neatnik/calendar/assets/1102783/79a3e8df-f2cc-424f-a400-224d8f302777)

So maybe you also want your calendar to be able to do this? If so, this is the PR for you...

I tested it with `layout=aligned-weekdays` and manually verified that for 2024 all the same weekdays are marked in this as in the original 1-page version. I did not mess with the `$first_weekdays` array at all, just the three loops that print months (headings, day-of-the-week cells, day-of-the-week cells in aligned-weekdays mode) replaced the `1`s and `12`s with `$month_first` and `$month_last`.

In theory, you might say "maybe we should just let `month_first` and `month_last` be parameters instead of hardcoding halves like this, so someone could do thirds or quarters?" and that would be a valid thing to say (and an easy change to make to this PR), but as I'm sending this PR to you, whom I've never met, I figured I would just add the fewest options with the cleanest changes and let you decide how to take it, if at all. Cheers :wave: 